### PR TITLE
Make post's feature image max-width: 100%

### DIFF
--- a/_sass/_page.scss
+++ b/_sass/_page.scss
@@ -20,8 +20,9 @@
 /* feature image */
 
 .entry-feature-image {
-	margin: 20px 0 0;
-	width: 100%;
+	margin: 20px auto 0;
+	max-width: 100%;
+	display: block;
 	@include media($medium) {
 		margin-top: -75px; /* move up to be overlapped by site logo */
 	}


### PR DESCRIPTION
Before the image scaled to the browser's width, leading to your image being scaled out too much, making it look crappy.
