### PR TITLE
Move developers information to data yaml file

### DIFF
--- a/_data/developers.yml
+++ b/_data/developers.yml
@@ -1,0 +1,83 @@
+- name: Anna Karpiuk
+  github: AnnaKarpiuk
+
+- name: Benjamin Brandt
+  github: benjaminbrandt
+
+- name: Roman Romanchuk
+  github: fatroom
+
+- name: Federico Palmieri
+  github: fedestylah
+
+- name: Florina Muntenescu
+  github: florina-muntenescu
+  twitter: FMuntenescu
+  slideshare: FlorinaMuntenescu
+
+- name: Henning Gross
+  github: gaffa
+
+- name: Paweł Polański
+  github: jaggernod
+
+- name: Johannes Braun
+  github: johannesbraun
+
+- name: Josiane Milanez
+  github: jomilanez
+
+- name: Kavya Hebbani
+  github: kavyaShreeHS
+
+- name: Tomasz Kaszkowiak
+  github: ktomek
+
+- name: Lennard Timm
+  github: lenn4rd
+
+- name: Lucia Payo
+  github: luciapayo
+
+- name: Maciej Walkowiak
+  github: maciejwalkowiak
+  twitter: maciejwalkowiak
+
+- name: Maria Fernandez Pajarez
+  github: mfernandezpajares
+
+- name: Tino Noack
+  github: noacktino
+
+- name: Peter Tackage
+  github: peter-tackage
+
+- name: Peter Krauss
+  github: pkrauss-asideas
+  twitter: pkatberlin
+
+- name: Artur Roszczyk
+  github: sevos
+
+- name: Nicola Miotto
+  github: sirnicolaz
+
+- name: Mike Paßberg
+  github: suxor42
+
+- name: Richard Lawrence
+  github: sweatyrichard
+
+- name: Tomasz Polański
+  github: tomaszpolanski
+  twitter: tpolansk
+  slideshare: polanskitomasz
+
+- name: Timo Ulich
+  github: ulich
+
+- name: Will Nolan
+  github: will-nolan
+
+- name: Robert Bordo
+  github: rbordo

--- a/about/index.md
+++ b/about/index.md
@@ -7,7 +7,7 @@ modified: 2014-08-08T19:44:38.564948-04:00
 <figure class="fith">
     {% assign devs = site.data.developers | sort: 'name' %}
     {% for developer in devs %}
-	    <a href="http://twitter.com/{{ if developer.twitter }}{{ developer.twitter}}{{ else }}UpdayDevs{{ endif }}" title="{{ developer.name }}"><img src="https://github.com/{{ developer.github }}.png" alt="image"></a>
+	    <a href="http://twitter.com/{% if developer.twitter != null %}{{ developer.twitter}}{% else %}UpdayDevs{% endif %}" title="{{ developer.name }}"><img src="https://github.com/{{ developer.github }}.png" alt="image"></a>
     {% endfor %}
   <figcaption>Our Updudettes & Updudes</figcaption>
 </figure>

--- a/about/index.md
+++ b/about/index.md
@@ -1,44 +1,13 @@
 ---
 layout: page
 title: About
-excerpt: "So Simple is a responsive Jekyll theme for your words and images."
+excerpt: "About"
 modified: 2014-08-08T19:44:38.564948-04:00
 ---
 <figure class="fith">
-	<a href="http://twitter.com/UpdayDevs" title="Alex"><img src="https://github.com/AncaTodirica.png" alt="image"></a>
-	<a href="http://twitter.com/UpdayDevs" title="Anca"><img src="https://github.com/AnnaKarpiuk.png" alt="image"></a>
-	<a href="http://twitter.com/UpdayDevs" title="Benni"><img src="https://github.com/benjaminbrandt.png" alt="image"></a>
-  <a href="http://twitter.com/UpdayDevs" title="Benni"><img src="https://github.com/chris146.png" alt="image"></a>
-	<a href="http://twitter.com/UpdayDevs" title="Dennis"><img src="https://github.com/deloeb.png" alt="image"></a>
-	<a href="http://twitter.com/UpdayDevs" title="Roman"><img src="https://github.com/fatroom.png" alt="image"></a>
-	<a href="http://twitter.com/UpdayDevs" title="Federico"><img src="https://github.com/fedestylah.png" alt="image"></a>
-	<a href="http://twitter.com/UpdayDevs" title="Florina"><img src="https://github.com/florina-muntenescu.png" alt="image"></a>
-	<a href="http://twitter.com/UpdayDevs" title="Henning"><img src="https://github.com/gaffa.png" alt="image"></a>
-	<a href="http://twitter.com/UpdayDevs" title="Harry"><img src="https://github.com/HarryDeal.png" alt="image"></a>
-	<a href="http://twitter.com/UpdayDevs" title="Pawel"><img src="https://github.com/jaggernod.png" alt="image"></a>
-	<a href="http://twitter.com/UpdayDevs" title="Johannes"><img src="https://github.com/johannesbraun.png" alt="image"></a>
-	<a href="http://twitter.com/UpdayDevs" title="Tomek"><img src="https://github.com/tomaszpolanski.png" alt="image"></a>
-	<a href="http://twitter.com/UpdayDevs" title="Alex"><img src="https://github.com/joker54.png" alt="image"></a>
-	<a href="http://twitter.com/UpdayDevs" title="Josiane"><img src="https://github.com/jomilanez.png" alt="image"></a>
-	<a href="http://twitter.com/UpdayDevs" title="Jona"><img src="https://github.com/jonadinges.png" alt="image"></a>
-	<a href="http://twitter.com/UpdayDevs" title="Kavya"><img src="https://github.com/kavyaShreeHS.png" alt="image"></a>
-	<a href="http://twitter.com/UpdayDevs" title="Andi"><img src="https://github.com/krnki.png" alt="image"></a>
-	<a href="http://twitter.com/UpdayDevs" title="Tomasz"><img src="https://github.com/ktomek.png" alt="image"></a>
-	<a href="http://twitter.com/UpdayDevs" title="Lennard"><img src="https://github.com/lenn4rd.png" alt="image"></a>
-	<a href="http://twitter.com/UpdayDevs" title="Lucia"><img src="https://github.com/luciapayo.png" alt="image"></a>
-	<a href="http://twitter.com/UpdayDevs" title="Maciej"><img src="https://github.com/maciejwalkowiak.png" alt="image"></a>
-	<a href="http://twitter.com/UpdayDevs" title="Maria"><img src="https://github.com/mfernandezpajares.png" alt="image"></a>
-	<a href="http://twitter.com/UpdayDevs" title="Timo"><img src="https://github.com/ulich.png" alt="image"></a>
-	<a href="http://twitter.com/UpdayDevs" title="Tino"><img src="https://github.com/noacktino.png" alt="image"></a>
-	<a href="http://twitter.com/UpdayDevs" title="Pablo"><img src="https://github.com/pabloqc.png" alt="image"></a>
-	<a href="http://twitter.com/UpdayDevs" title="Peter"><img src="https://github.com/peter-tackage.png" alt="image"></a>
-	<a href="http://twitter.com/UpdayDevs" title="Peter"><img src="https://github.com/pkrauss-asideas.png" alt="image"></a>
-	<a href="http://twitter.com/UpdayDevs" title="Robert"><img src="https://github.com/rbordo.png" alt="image"></a>
-	<a href="http://twitter.com/UpdayDevs" title="Artur"><img src="https://github.com/sevos.png" alt="image"></a>
-	<a href="http://twitter.com/UpdayDevs" title="Simone"><img src="https://github.com/SimoneDzapoGarcia.png" alt="image"></a>
-	<a href="http://twitter.com/UpdayDevs" title="Nicola"><img src="https://github.com/sirnicolaz.png" alt="image"></a>
-	<a href="http://twitter.com/UpdayDevs" title="Mike"><img src="https://github.com/suxor42.png" alt="image"></a>
-	<a href="http://twitter.com/UpdayDevs" title="Richard"><img src="https://github.com/sweatyrichard.png" alt="image"></a>
-	<a href="http://twitter.com/UpdayDevs" title="Will"><img src="https://github.com/will-nolan.png" alt="image"></a>
+    {% assign devs = site.data.developers | sort: 'name' %}
+    {% for developer in devs %}
+	    <a href="http://twitter.com/{{ if developer.twitter }}{{ developer.twitter}}{{ else }}UpdayDevs{{ endif }}" title="{{ developer.name }}"><img src="https://github.com/{{ developer.github }}.png" alt="image"></a>
+    {% endfor %}
   <figcaption>Our Updudettes & Updudes</figcaption>
 </figure>


### PR DESCRIPTION
- it's easier to modify layout when data is moved to separate file and HTML contains only a template
- if developer has his own twitter account - his account is linked to photo, if not links redirects to "UpdayDevs" at twitter - added personal twitter account to few devs that I know on twitter
- added links to Slideshare for people who I know use it - I believe that in the future about page could be extended to link to more social profiles in similar fashion as https://spring.io/team or https://softwaremill.com/meet-the-team/ does (I like Softwaremill format even more than Spring)
- only developers with real name on github are included in yaml file (I am not sure if they want to be mentioned on public page if they don't use their name on github)
